### PR TITLE
Fixing empty result response body.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lambda-api-factory",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "",
   "main": "build/index.js",
   "scripts": {

--- a/src/__tests__/apiResponseWrapper.test.js
+++ b/src/__tests__/apiResponseWrapper.test.js
@@ -34,7 +34,7 @@ test('return success response for array', () => {
 test('return not found response', () => {
   const res = createNotFoundResponse()
   expect(res).toEqual({
-    body: 'Resource not found',
+    body: { message: 'Resource not found'},
     headers: { 'Content-Type': 'application/json' },
     statusCode: 404,
   })

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -111,7 +111,7 @@ test('test simple api service that returns empty result', async () => {
     [
       null,
       {
-        body: 'Resource not found',
+        body: { message: 'Resource not found' },
         headers: { 'Content-Type': 'application/json' },
         statusCode: 404,
       },

--- a/src/apiResponseWrapper.js
+++ b/src/apiResponseWrapper.js
@@ -26,5 +26,7 @@ export const createNotFoundResponse = () => ({
   headers: {
     'Content-Type': 'application/json',
   },
-  body: 'Resource not found',
+  body: {
+    message: 'Resource not found',
+  },
 })


### PR DESCRIPTION
When hitting empty results, the library is returning a response different from what is sending in the header thus causing some parse errors if the client is following the `content-type` header in the response. 

The fix consists in sending back the `body` as an object containing the message that before was just plain text.

Future things that could be added to it would be:

- Based on the `content-type` we can answer in different formats.
- Enable the injection of data in the header if wanted.  