### PR TITLE
Fixing empty result response body. (#1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lambda-api-factory",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "",
   "main": "build/index.js",
   "scripts": {

--- a/src/__tests__/apiResponseWrapper.test.js
+++ b/src/__tests__/apiResponseWrapper.test.js
@@ -34,7 +34,7 @@ test('return success response for array', () => {
 test('return not found response', () => {
   const res = createNotFoundResponse()
   expect(res).toEqual({
-    body: 'Resource not found',
+    body: { message: 'Resource not found'},
     headers: { 'Content-Type': 'application/json' },
     statusCode: 404,
   })

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -111,7 +111,7 @@ test('test simple api service that returns empty result', async () => {
     [
       null,
       {
-        body: 'Resource not found',
+        body: { message: 'Resource not found' },
         headers: { 'Content-Type': 'application/json' },
         statusCode: 404,
       },

--- a/src/apiResponseWrapper.js
+++ b/src/apiResponseWrapper.js
@@ -26,5 +26,7 @@ export const createNotFoundResponse = () => ({
   headers: {
     'Content-Type': 'application/json',
   },
-  body: 'Resource not found',
+  body: {
+    message: 'Resource not found',
+  },
 })


### PR DESCRIPTION
* Fixing the response for empty results to match the content-type sent back in the response.

* Version bumping.